### PR TITLE
Fix Typo "breath" to "breathe"

### DIFF
--- a/Classes/UI/SparkSetupResultViewController.m
+++ b/Classes/UI/SparkSetupResultViewController.m
@@ -198,7 +198,7 @@
     {
         // Update zero notice to user
         // TODO: condition message only if its really getting update zero
-        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Firmware update" message:@"If this is the first time you are setting up this device it might blink its LED in magenta color for a while, this means the device is currently updating its firmware from the cloud to the latest version. Please be patient and do not press the reset button. Device LED will breath cyan once update has completed and it has come online." delegate:nil cancelButtonTitle:@"Understood" otherButtonTitles:nil];
+        UIAlertView *alert = [[UIAlertView alloc] initWithTitle:@"Firmware update" message:@"If this is the first time you are setting up this device it might blink its LED in magenta color for a while, this means the device is currently updating its firmware from the cloud to the latest version. Please be patient and do not press the reset button. Device LED will breathe cyan once update has completed and it has come online." delegate:nil cancelButtonTitle:@"Understood" otherButtonTitles:nil];
         [alert show];
 
         userInfo[kSparkSetupDidFinishStateKey] = @(SparkSetupMainControllerResultSuccess);


### PR DESCRIPTION
Noticed this while setting up a Photon...
