### PR TITLE
Added support for disabling the log out button.

### DIFF
--- a/Classes/UI/SparkGetReadyViewController.m
+++ b/Classes/UI/SparkGetReadyViewController.m
@@ -72,6 +72,9 @@
         [self.logoutButton setTitle:@"Log in" forState:UIControlStateNormal];
         self.loggedInLabel.text = @"";
     }
+    if ([SparkSetupCustomization sharedInstance].disableLogOutOption) {
+        self.logoutButton.hidden = @YES;
+    }
 }
 
 - (void)didReceiveMemoryWarning {

--- a/Classes/User/SparkSetupCustomization.h
+++ b/Classes/User/SparkSetupCustomization.h
@@ -75,5 +75,6 @@
 
 @property (nonatomic, assign) BOOL allowSkipAuthentication;      // allow user to skip authentication 
 @property (nonatomic, strong) NSString *skipAuthenticationMessage;    // Prompt to display to user when he's requesting to skip authentication
+@property (nonatomic) BOOL disableLogOutOption; // Do not allow the user to log out from the GetReady page.
 
 @end

--- a/Classes/User/SparkSetupCustomization.m
+++ b/Classes/User/SparkSetupCustomization.m
@@ -91,7 +91,7 @@
 
         self.allowSkipAuthentication = NO;
         self.skipAuthenticationMessage = @"Skipping authentication will allow you to configure Wi-Fi credentials to your device but it will not be claimed to your account. Are you sure you want to skip authentication?";
-        
+        self.disableLogOutOption = NO;
         return self;
     }
     


### PR DESCRIPTION
In an app that I am building I have my own custom views that handle account management (logging in, out and creating an account). It would be really nice to still be able to use the spark-setup project for the workflow involved with setting up a device and adding it the the users account. I added an option to the customization class that hides the logout button on the GetReady view so the user can't log out from there and be navigated to the login screen that's part of this project.
