### PR TITLE
Add support for disabling the device rename screen.

### DIFF
--- a/Classes/UI/SparkConnectingProgressViewController.m
+++ b/Classes/UI/SparkConnectingProgressViewController.m
@@ -15,6 +15,7 @@
 #import "Reachability.h"
 #import "SparkCloud.h"
 #import "SparkSetupUIElements.h"
+#import "SparkSetupCustomization.h"
 #import "SparkSetupResultViewController.h"
 #ifdef ANALYTICS
 #import "Mixpanel.h"
@@ -443,7 +444,11 @@ typedef NS_ENUM(NSInteger, SparkSetupConnectionProgressState) {
                     [self nextConnectionProgressState];
                     
                     if (device.connected)
-                        self.setupResult = SparkSetupResultSuccess;
+                        
+                        if ([SparkSetupCustomization sharedInstance].disableDeviceRename == YES)
+                            [SparkSetupResultViewController exitSetup:self.setupResult :self.device];
+                        else
+                            self.setupResult = SparkSetupResultSuccess;
                     else
                         self.setupResult = SparkSetupResultSuccessDeviceOffline;
                     

--- a/Classes/UI/SparkSetupResultViewController.h
+++ b/Classes/UI/SparkSetupResultViewController.h
@@ -23,4 +23,12 @@ typedef NS_ENUM(NSInteger, SparkSetupResult) {
 @property (nonatomic, strong) SparkDevice *device;
 @property (nonatomic) SparkSetupResult setupResult;
 
+/**
+ *  Closes the SparkSetup flow by triggering the observable on the SparkSetupMainController
+ *
+ *  @param setupResult The SparkSetupResult
+ *  @param device      The current spark device
+ */
++(void)exitSetup:(SparkSetupResult)setupResult :(SparkDevice *)device;
+
 @end

--- a/Classes/UI/SparkSetupResultViewController.m
+++ b/Classes/UI/SparkSetupResultViewController.m
@@ -29,7 +29,7 @@
 
 @implementation SparkSetupResultViewController
 
-- (void)viewDidLoad {
+-(void)viewDidLoad {
     [super viewDidLoad];
     // set logo
     self.brandImageView.image = [SparkSetupCustomization sharedInstance].brandImage;
@@ -53,7 +53,7 @@
 
 }
 
-- (void)didReceiveMemoryWarning {
+-(void)didReceiveMemoryWarning {
     [super didReceiveMemoryWarning];
     // Dispose of any resources that can be recreated.
 }
@@ -201,12 +201,15 @@
 }
 
 
+-(IBAction)doneButtonTapped:(id)sender
+{
+    [SparkSetupResultViewController exitSetup:self.setupResult :self.device];
+}
 
-
-- (IBAction)doneButtonTapped:(id)sender
++ (void)exitSetup:(SparkSetupResult)setupResult :(SparkDevice *)device
 {
     NSMutableDictionary *userInfo = [NSMutableDictionary new];
-    if (self.setupResult == SparkSetupResultSuccess)
+    if (setupResult == SparkSetupResultSuccess)
     {
         // Update zero notice to user
         // TODO: condition message only if its really getting update zero
@@ -215,10 +218,10 @@
 
         userInfo[kSparkSetupDidFinishStateKey] = @(SparkSetupMainControllerResultSuccess);
         
-        if (self.device)
-            userInfo[kSparkSetupDidFinishDeviceKey] = self.device;
+        if (device)
+            userInfo[kSparkSetupDidFinishDeviceKey] = device;
     }
-    else if (self.setupResult == SparkSetupResultSuccessUnknown)
+    else if (setupResult == SparkSetupResultSuccessUnknown)
     {
         userInfo[kSparkSetupDidFinishStateKey] = @(SparkSetupMainControllerResultSuccessNotClaimed);
     }
@@ -235,7 +238,7 @@
 }
 
 
-- (IBAction)troubleshootingButtonTouched:(id)sender
+-(IBAction)troubleshootingButtonTouched:(id)sender
 {
     
     SparkSetupWebViewController* webVC = [[UIStoryboard storyboardWithName:@"setup" bundle:[NSBundle bundleWithIdentifier:SPARK_SETUP_RESOURCE_BUNDLE_IDENTIFIER]] instantiateViewControllerWithIdentifier:@"webview"];

--- a/Classes/User/SparkSetupCustomization.h
+++ b/Classes/User/SparkSetupCustomization.h
@@ -76,5 +76,6 @@
 @property (nonatomic, assign) BOOL allowSkipAuthentication;      // allow user to skip authentication 
 @property (nonatomic, strong) NSString *skipAuthenticationMessage;    // Prompt to display to user when he's requesting to skip authentication
 @property (nonatomic) BOOL disableLogOutOption; // Do not allow the user to log out from the GetReady page.
+@property (nonatomic) BOOL disableDeviceRename; // Do not allow the user to rename the device.
 
 @end

--- a/Classes/User/SparkSetupCustomization.m
+++ b/Classes/User/SparkSetupCustomization.m
@@ -92,6 +92,7 @@
         self.allowSkipAuthentication = NO;
         self.skipAuthenticationMessage = @"Skipping authentication will allow you to configure Wi-Fi credentials to your device but it will not be claimed to your account. Are you sure you want to skip authentication?";
         self.disableLogOutOption = NO;
+        self.disableDeviceRename = NO;
         return self;
     }
     


### PR DESCRIPTION
`SparkSetupResultViewController` now has a static method that closes the setup flow. 

This static method is called by the `SparkConnectProgressViewController` if the customization option `disableDeviceRename` is set to true.
