### PR TITLE
Carthage/Build added to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ DerivedData
 *.ipa
 *.xcuserstate
 
+# Carthage
+# Avoids `dirty` git flags when Carthage is ran with `--use-submodules`
+Carthage/Build
+
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However


### PR DESCRIPTION
When this framework is added via carthage with the `--use-submodules` flag, it builds it in the `./Carthage/Checkouts/spark-setup-ios/Carthage/Build` directory, marking this submodule as dirty. 

Adding `Carthage/Build` to the gitignore list fixes this :)
